### PR TITLE
If berksfile contains only metadata there is no completion

### DIFF
--- a/berkshelf-complete.sh
+++ b/berkshelf-complete.sh
@@ -33,13 +33,10 @@ _berkshelf_commands() {
 
 _berkshelf_cookbooks() {
   local file=${BERKSHELF_BERKSFILE:-Berksfile}
-  if [ -e $file ]; then
-    # strip all quotes from cookbook name and remove trailing comma, if any
-    grep -w '^cookbook' $file \
-      | awk '{ print $2 }' \
-      | sed 's/"//g' \
-      | sed "s/'//g" \
-      | sed 's/,$//'
+  local lock_file="${file}.lock"
+  if [ -e $lock_file ]; then
+    # trying to detect cookbook names from lock file using format '<cookbook_name> (x.y.z)'
+    grep -o -e '[^ ]\+ ([0-9]\+\.[0-9]\+\.[0-9]\+)' $lock_file | sed 's/\([^ ]\+\) .*$/\1/'
   fi
 }
 

--- a/berkshelf-complete.sh
+++ b/berkshelf-complete.sh
@@ -45,16 +45,13 @@ _local_cookbooks() {
 }
 
 _berkshelf() {
-  # local curr prev commands
+  # local curr action commands
   COMPREPLY=()
   curr="${COMP_WORDS[COMP_CWORD]}"
-  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  action="${COMP_WORDS[1]}"
 
-  # List of commands to complete
-  commands=`_berkshelf_commands`
-
-  case "${prev}" in
-    "open"|"outdated"|"show"|"update"|"upload")
+  case "${action}" in
+    "info"|"open"|"outdated"|"show"|"update"|"upload"|"contingent")
       local berkshelf_cookbooks=`_berkshelf_cookbooks`
       local local_cookbooks=`_local_cookbooks`
       local cookbooks=`echo $berkshelf_cookbooks $local_cookbooks | sort -n | uniq`
@@ -62,8 +59,12 @@ _berkshelf() {
       return 0
       ;;
     *)
+      [ "$COMP_CWORD" -gt "1" ] && return 0
       ;;
   esac
+
+  # List of commands to complete
+  commands=`_berkshelf_commands`
 
   COMPREPLY=($(compgen -W "${commands}" -- ${curr}))
   return 0


### PR DESCRIPTION
I'm not sure I doing this right, but it works for me. Hope for you too.

For berkshelf auto completion I'm assuming that Berksfile.lock is present. Otherwise there is no sense in `berks update`, `berks outdated`, etc.

Trying to detect cookbook names from lock file.

Also stop completion for berkshelf commands after first word found. Looks like Berkshelf supports only single command at once. 
